### PR TITLE
Use ascii to print table for correct rendering in all formats

### DIFF
--- a/source/01-introduction.md
+++ b/source/01-introduction.md
@@ -14,8 +14,8 @@ qplot(hp, mpg, data = mtcars) + geom_smooth()
 And here is a table created with the **xtable** package:
 
 ``` {r intro-table, results='asis'}
-library(xtable)
-print(xtable(head(mtcars[, 1:5])), type='html')
+library(ascii)
+print(ascii(head(mtcars[, 1:5]), include.rownames = FALSE), type = 'rest')
 ````
 
 TODO: Sweave. An overview of the following chapters.


### PR DESCRIPTION
Using the `html` format does not lead to correct rendering of tables. Pandoc recognizes multiple table formats, of which the `rest` format is already included in `ascii`. I have modified these lines so that they are correctly rendered in the pdf format.
