### PR TITLE
Update knit

### DIFF
--- a/knit
+++ b/knit
@@ -6,11 +6,11 @@ library(knitr)
 
 ## use a custom pattern list: begin by ``` {r code begin} and end by ````; `ri
 ## [inline code] ir`; `ro [global options] or`
-pat_gfm()
+render_markdown()
 
 ## use GFM as the output format: R code in ```r and ``` (both GitHub and pandoc
 ## recognize it)
-render_gfm()
+render_markdown()
 
 ## global chunk options: use high quality Cairo PNG device
 pdf.options(pointsize = 10)  # smaller pointsize for recording plots


### PR DESCRIPTION
replaced render_gfm() to render_markdown() to make `./knit pdf` work correctly.
